### PR TITLE
Forwarded PUT and PATCH requests not sending validated_data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "spook"
-version = "3.2.7"
+version = "3.2.8"
 description = "Django Rest Framework library to interconnect external APIs"
 authors = ["Pablo Moreno <pablomoreno.inf@gmail.com>"]
 license = "MIT"

--- a/spook/resources.py
+++ b/spook/resources.py
@@ -196,11 +196,11 @@ class APIResource(object):
         :param query: Query params
         :return: JSON response as a dict
         """
-        self.validate(data, action="update")
+        validated_data = self.validate(data, action="update")
         response = self.http.put(
-            self.get_url(pk), json=data, headers=self.get_headers(), params=query
+            self.get_url(pk), json=validated_data, headers=self.get_headers(), params=query
         )
-        self.handle_server_errors(response, data=data)
+        self.handle_server_errors(response, data=validated_data)
         data = self.get_response_data(response)
         data = self.map_response(data, action="update", status=response.status_code)
 
@@ -214,11 +214,11 @@ class APIResource(object):
         :param query: Query params
         :return: JSON response as a dict
         """
-        self.validate(data, action="update")
+        validated_data = self.validate(data, action="update")
         response = self.http.patch(
-            self.get_url(pk), json=data, headers=self.get_headers(), params=query
+            self.get_url(pk), json=validated_data, headers=self.get_headers(), params=query
         )
-        self.handle_server_errors(response, data=data)
+        self.handle_server_errors(response, data=validated_data)
         data = self.get_response_data(response)
         data = self.map_response(
             data, action="partial_update", status=response.status_code


### PR DESCRIPTION
PUT and PATCH requests must send validated_data because it applies the serializer class